### PR TITLE
[WIP][HDP-6846] First go at implementing data retention enforcement.

### DIFF
--- a/app-conf/GeneralConf.xml
+++ b/app-conf/GeneralConf.xml
@@ -52,7 +52,7 @@
   </property>
   <property>
     <name>drelephant.analysis.purge.batch.size</name>
-    <value>10000</value>
+    <value>1000</value>
     <description>Batch size of purge operation</description>
   </property>
   <property>

--- a/app-conf/GeneralConf.xml
+++ b/app-conf/GeneralConf.xml
@@ -45,4 +45,19 @@
     <name>drelephant.analysis.fetch.initial.windowMillis</name>
     <value>3600000</value>
   </property> -->
+  <property>
+    <name>drelephant.analysis.retention.period</name>
+    <value>30</value>
+    <description>Number of days of analysis to be kept in the database</description>
+  </property>
+  <property>
+    <name>drelephant.analysis.purge.batch.size</name>
+    <value>10000</value>
+    <description>Batch size of purge operation</description>
+  </property>
+  <property>
+    <name>drelephant.analysis.purge.operation.interval</name>
+    <value>60000</value>
+    <description>Interval between purge operations in milliseconds</description>
+  </property>
 </configuration>

--- a/app/com/linkedin/drelephant/analysis/AnalyticJob.java
+++ b/app/com/linkedin/drelephant/analysis/AnalyticJob.java
@@ -290,10 +290,8 @@ public class AnalyticJob {
 
       // Load Heuristic Details
       for (HeuristicResultDetails heuristicResultDetails : heuristicResult.getHeuristicResultDetails()) {
-        AppHeuristicResultDetails heuristicDetail = new AppHeuristicResultDetails();
-        heuristicDetail.yarnAppHeuristicResult = detail;
-        heuristicDetail.name = Utils.truncateField(heuristicResultDetails.getName(),
-            AppHeuristicResultDetails.NAME_LIMIT, getAppId());
+        AppHeuristicResultDetails heuristicDetail = new AppHeuristicResultDetails(detail, Utils.truncateField(heuristicResultDetails.getName(),
+                AppHeuristicResultDetails.NAME_LIMIT, getAppId()));
         heuristicDetail.value = Utils.truncateField(heuristicResultDetails.getValue(),
             AppHeuristicResultDetails.VALUE_LIMIT, getAppId());
         heuristicDetail.details = Utils.truncateField(heuristicResultDetails.getDetails(),

--- a/app/com/linkedin/drelephant/purge/AppResultPurger.java
+++ b/app/com/linkedin/drelephant/purge/AppResultPurger.java
@@ -1,0 +1,29 @@
+package com.linkedin.drelephant.purge;
+
+import models.AppResult;
+import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
+
+
+public class AppResultPurger implements ElephantPurger {
+
+    private static final Logger logger = Logger.getLogger(AppResultPurger.class);
+
+    public PurgeResult purgeOlderThan (int days, int batchSize, DateTime startingFrom) {
+        int deletedRecords;
+        int totalDeletedRecords = 0;
+        int deleteBatches = 0;
+
+        do {
+            deletedRecords = AppResult.deleteOlderThan(days, batchSize, DateTime.now());
+            if (deletedRecords > 0) {
+                totalDeletedRecords += deletedRecords;
+                deleteBatches++;
+            }
+
+            logger.info("Purged " + deletedRecords + " records older than " + days + " from the database");
+        } while (deletedRecords > 0);
+
+        return new PurgeResult(totalDeletedRecords, deleteBatches);
+    }
+}

--- a/app/com/linkedin/drelephant/purge/ElephantPurger.java
+++ b/app/com/linkedin/drelephant/purge/ElephantPurger.java
@@ -1,0 +1,8 @@
+package com.linkedin.drelephant.purge;
+
+import org.joda.time.DateTime;
+
+public interface ElephantPurger {
+
+    PurgeResult purgeOlderThan (int days, int batchSize, DateTime startingFrom);
+}

--- a/app/com/linkedin/drelephant/purge/PurgeResult.java
+++ b/app/com/linkedin/drelephant/purge/PurgeResult.java
@@ -1,0 +1,16 @@
+package com.linkedin.drelephant.purge;
+
+public class PurgeResult {
+
+    private int _numRecordsDeleted;
+    private int _numBatches;
+
+    public PurgeResult(int numRecordsDeleted, int numBatches) {
+        _numRecordsDeleted = numRecordsDeleted;
+        _numBatches = numBatches;
+    }
+
+    public int getNumRecordsDeleted() { return _numRecordsDeleted; }
+
+    public int getNumBatches() { return _numBatches; }
+}

--- a/app/models/AppHeuristicResult.java
+++ b/app/models/AppHeuristicResult.java
@@ -64,7 +64,7 @@ public class AppHeuristicResult extends Model {
   public int id;
 
   @JsonBackReference
-  @ManyToOne(cascade = CascadeType.ALL)
+  @ManyToOne
   public AppResult yarnAppResult;
 
   @Column(length = HEURISTIC_CLASS_LIMIT, nullable = false)
@@ -80,7 +80,11 @@ public class AppHeuristicResult extends Model {
   public int score;
 
   @JsonManagedReference
-  @OneToMany(cascade = CascadeType.ALL, mappedBy = "yarnAppHeuristicResult")
+  @OneToMany(cascade = CascadeType.ALL, mappedBy = "yarnAppHeuristicResult", orphanRemoval = true)
   public List<AppHeuristicResultDetails> yarnAppHeuristicResultDetails;
+
+  public int getId() {
+    return this.id;
+  }
 
 }

--- a/app/models/AppHeuristicResultDetails.java
+++ b/app/models/AppHeuristicResultDetails.java
@@ -17,18 +17,14 @@
 package models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
 
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 
 import play.db.ebean.Model;
+
+import java.util.UUID;
 
 
 @Entity
@@ -49,11 +45,15 @@ public class AppHeuristicResultDetails extends Model {
     public static final String DETAILS = "details";
   }
 
+  @EmbeddedId
+  public AppHeuristicResultDetailsPK compositePK;
+
   @JsonBackReference
-  @ManyToOne(cascade = CascadeType.ALL)
+  @ManyToOne
+  @JoinColumn(name = "yarn_app_heuristic_result_id", insertable = false, updatable = false)
   public AppHeuristicResult yarnAppHeuristicResult;
 
-  @Column(length=NAME_LIMIT, nullable = false)
+  @Column(length=NAME_LIMIT, nullable = false, insertable = false, updatable = false)
   public String name;
 
   @Column(length=VALUE_LIMIT, nullable = false)
@@ -61,4 +61,10 @@ public class AppHeuristicResultDetails extends Model {
 
   @Column(nullable = true)
   public String details;
+
+  public AppHeuristicResultDetails(AppHeuristicResult yarnAppHeuristicResult, String name) {
+    this.compositePK = new AppHeuristicResultDetailsPK(yarnAppHeuristicResult, name);
+    this.yarnAppHeuristicResult = yarnAppHeuristicResult;
+    this.name = name;
+  }
 }

--- a/app/models/AppHeuristicResultDetailsPK.java
+++ b/app/models/AppHeuristicResultDetailsPK.java
@@ -1,0 +1,60 @@
+package models;
+
+import play.db.ebean.Model;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+
+/**
+ * Created by a.savarin on 25/09/2017.
+ */
+
+@Embeddable
+public class AppHeuristicResultDetailsPK extends Model implements Serializable {
+
+    private static final long serialVersionUID = 4L;
+
+    public static final int NAME_LIMIT = 128;
+
+    @Column(name = "yarn_app_heuristic_result_id", nullable = false)
+    public AppHeuristicResult yarnAppHeuristicResult;
+
+    @Column(name = "name", length = NAME_LIMIT, nullable = false)
+    public String name;
+
+    public AppHeuristicResultDetailsPK(AppHeuristicResult yarnAppHeuristicResultId, String name) {
+        this.yarnAppHeuristicResult = yarnAppHeuristicResultId;
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        final AppHeuristicResultDetailsPK other = (AppHeuristicResultDetailsPK) obj;
+        if (this.yarnAppHeuristicResult != other.yarnAppHeuristicResult) {
+            return false;
+        }
+
+        if ((this.name == null) ? (other.name != null) : !this.name.equals(other.name)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 12;
+        hash = 36 * hash + (this.yarnAppHeuristicResult != null ? this.yarnAppHeuristicResult.hashCode() : 0);
+        hash = 36 * hash + (this.name != null ? this.name.hashCode() : 0);
+        return hash;
+    }
+
+}

--- a/app/models/AppResult.java
+++ b/app/models/AppResult.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.linkedin.drelephant.analysis.Severity;
 
 import com.linkedin.drelephant.util.Utils;
-import java.util.Date;
 
 import org.joda.time.DateTime;
 import play.db.ebean.Model;
@@ -170,11 +169,15 @@ public class AppResult extends Model {
   public static Finder<String, AppResult> find = new Finder<String, AppResult>(String.class, AppResult.class);
 
   @Transactional
-  public static int deleteOlderThan(int days, int batchSize) {
-    List<AppResult> toDelete =
-            find.where().lt("finishTime", DateTime.now().minusDays(days).getMillis()).setMaxRows(batchSize).findList();
-    for (AppResult appResult : toDelete) {
-      Ebean.delete(appResult);
+  public static int deleteOlderThan(int days, int batchSize, DateTime startingFrom) {
+    List<Object> toDelete = find
+        .where()
+        .lt("finishTime", startingFrom.minusDays(days).getMillis())
+        .setMaxRows(batchSize)
+        .findIds();
+
+    for (Object id : toDelete) {
+      Ebean.delete(AppResult.class, id);
     }
 
     return toDelete.size();

--- a/app/models/AppResult.java
+++ b/app/models/AppResult.java
@@ -16,12 +16,16 @@
 
 package models;
 
+import com.avaje.ebean.Ebean;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.linkedin.drelephant.analysis.Severity;
 
 import com.linkedin.drelephant.util.Utils;
 import java.util.Date;
+
+import org.joda.time.DateTime;
 import play.db.ebean.Model;
+import play.db.ebean.Transactional;
 
 import java.util.List;
 
@@ -164,4 +168,15 @@ public class AppResult extends Model {
   public List<AppHeuristicResult> yarnAppHeuristicResults;
 
   public static Finder<String, AppResult> find = new Finder<String, AppResult>(String.class, AppResult.class);
+
+  @Transactional
+  public static int deleteOlderThan(int days, int batchSize) {
+    List<AppResult> toDelete =
+            find.where().lt("finishTime", DateTime.now().minusDays(days).getMillis()).setMaxRows(batchSize).findList();
+    for (AppResult appResult : toDelete) {
+      Ebean.delete(appResult);
+    }
+
+    return toDelete.size();
+  }
 }

--- a/conf/ebean.properties
+++ b/conf/ebean.properties
@@ -1,0 +1,2 @@
+ebean.ddl.generate=true
+ebean.ddl.run=false

--- a/test/com/linkedin/drelephant/purge/AppResultPurgerTest.java
+++ b/test/com/linkedin/drelephant/purge/AppResultPurgerTest.java
@@ -1,0 +1,56 @@
+package com.linkedin.drelephant.purge;
+
+import common.DBTestUtil;
+import org.joda.time.DateTime;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import play.test.FakeApplication;
+import play.test.Helpers;
+
+
+import static common.TestConstants.*;
+import static org.junit.Assert.assertTrue;
+
+import static common.DBTestUtil.initDB;
+import static play.test.Helpers.fakeApplication;
+import static play.test.Helpers.running;
+import static play.test.Helpers.testServer;
+
+public class AppResultPurgerTest {
+
+    public static FakeApplication app;
+
+    @BeforeClass
+    public static void startApp() {
+        app = fakeApplication(DBTestUtil.dbConn());
+    }
+
+    @AfterClass
+    public static void stopApp() {
+        Helpers.stop(app);
+    }
+
+    @Test
+    public void lowRetentionHasDeletion() {
+
+        running(testServer(TEST_SERVER_PORT, app), new Runnable() {
+            public void run() {
+                populateTestData();
+
+                PurgeResult result = new AppResultPurger().purgeOlderThan(1, 2, DateTime.now());
+
+                assertTrue("All records were deleted", result.getNumRecordsDeleted() == 2);
+                assertTrue("One batch of deletion were performed", result.getNumBatches() == 1);
+            }
+        });
+    }
+
+    private void populateTestData() {
+        try {
+            initDB();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/common/DBTestUtil.java
+++ b/test/common/DBTestUtil.java
@@ -21,13 +21,27 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.io.IOUtils;
 import play.db.DB;
 
-import static common.TestConstants.TEST_DATA_FILE;
+import static common.TestConstants.*;
 
 
 public class DBTestUtil {
+
+  public static Map<String, String> dbConn() {
+
+    Map<String, String> dbConn = new HashMap<String, String>();
+    dbConn.put(DB_DEFAULT_DRIVER_KEY, DB_DEFAULT_DRIVER_VALUE);
+    dbConn.put(DB_DEFAULT_URL_KEY, DB_DEFAULT_URL_VALUE);
+    dbConn.put(EVOLUTION_PLUGIN_KEY, EVOLUTION_PLUGIN_VALUE);
+    dbConn.put(APPLY_EVOLUTIONS_DEFAULT_KEY, APPLY_EVOLUTIONS_DEFAULT_VALUE);
+
+    return dbConn;
+  }
 
   public static void initDB()
       throws IOException, SQLException {

--- a/test/rest/RestAPITest.java
+++ b/test/rest/RestAPITest.java
@@ -61,12 +61,6 @@ public class RestAPITest {
 
   @Before
   public void setup() {
-    Map<String, String> dbConn = new HashMap<String, String>();
-    dbConn.put(DB_DEFAULT_DRIVER_KEY, DB_DEFAULT_DRIVER_VALUE);
-    dbConn.put(DB_DEFAULT_URL_KEY, DB_DEFAULT_URL_VALUE);
-    dbConn.put(EVOLUTION_PLUGIN_KEY, EVOLUTION_PLUGIN_VALUE);
-    dbConn.put(APPLY_EVOLUTIONS_DEFAULT_KEY, APPLY_EVOLUTIONS_DEFAULT_VALUE);
-
     GlobalSettings gs = new GlobalSettings() {
       @Override
       public void onStart(Application app) {
@@ -74,7 +68,7 @@ public class RestAPITest {
       }
     };
 
-    fakeApp = fakeApplication(dbConn, gs);
+    fakeApp = fakeApplication(DBTestUtil.dbConn(), gs);
   }
 
   /**


### PR DESCRIPTION
(Outdated. Used to launch initial discussions)

[HDP-6846] Basic query to delete a batch

[HDP-6846] Configuration values setting and parsing for retention enforcement

[HDP-6846] Adding basic thread to do the DB purging

I have the following questions:

1 -

what about testability? I had in mind to do the following tests:
--> config value: valid/invalid; invalid config = no purge
--> config value + older rows -> rows deleted
--> config value + newer rows -> no deletion
--> num rows > batch size -> row deletion in multiple iterations
however, how can I really test ElephantRunner? does the logic belong elsewhere? moving it risks inconsistency
2 -

failed fetches are given a retry interval before stopping for THAT attempt (i.e., fetch every minute, but retry 3 times before going back after a minute). is this retry necessary for purge? seems like overkill but thought i would ask.
3 -

number of jobs skipped or analyzed is exposed as a rest api queryable metric. for the purge to be "feature-complete," does the number of jobs purged need to be exposed as well?
4 -

should fetch and purge settings be refactored into separate, proper objects, analogous to scheduler settings, etc.?
5 - any other feedback...